### PR TITLE
Fix reported size

### DIFF
--- a/README-no-images.md
+++ b/README-no-images.md
@@ -1,7 +1,7 @@
 # Gloomhaven Rule Book
 An unofficial lightweight, searchable copy of the rule book. All text is taken directly from the official rule book and any mistakes are my own.
 
-- [README.md](README.md) contains all the relevant images from the rule book and weighs in at about 16MB.
+- [README.md](README.md) contains all the relevant images from the rule book and weighs in at about 6MB.
 - [README-no-large-images.md](README-no-large-images.md) has most of the screenshots from the rule book replaced with links to those images and is only about 2MB.
 - [README-no-images.md](README-no-images.md) contains no images at all (only links to them) and is less than 500KB in size.
 

--- a/README-no-large-images.md
+++ b/README-no-large-images.md
@@ -1,7 +1,7 @@
 # Gloomhaven Rule Book
 An unofficial lightweight, searchable copy of the rule book. All text is taken directly from the official rule book and any mistakes are my own.
 
-- [README.md](README.md) contains all the relevant images from the rule book and weighs in at about 16MB.
+- [README.md](README.md) contains all the relevant images from the rule book and weighs in at about 6MB.
 - [README-no-large-images.md](README-no-large-images.md) has most of the screenshots from the rule book replaced with links to those images and is only about 2MB.
 - [README-no-images.md](README-no-images.md) contains no images at all (only links to them) and is less than 500KB in size.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gloomhaven Rule Book
 An unofficial lightweight, searchable copy of the rule book. All text is taken directly from the official rule book and any mistakes are my own. There are three versions of this document:
 
-- [README.md](README.md) contains all the relevant images from the rule book and weighs in at about 16MB.
+- [README.md](README.md) contains all the relevant images from the rule book and weighs in at about 6MB.
 - [README-no-large-images.md](README-no-large-images.md) has most of the screenshots from the rule book replaced with links to those images and is only about 2MB.
 - [README-no-images.md](README-no-images.md) contains no images at all (only links to them) and is less than 500KB in size.
 


### PR DESCRIPTION
The version with all images said it was 16 MB, but should be 5.5 MB (see:
https://www.reddit.com/r/Gloomhaven/comments/91rl6o/lightweight_searchable_copy_of_the_rule_book/).

Rounding to 6 MB.